### PR TITLE
Fix .my.cnf so that mysqldump doesn't complain, fixes #43 PULL 2016-03-06 #TRIVIALREVIEW

### DIFF
--- a/files/root/mysqlclient.cnf
+++ b/files/root/mysqlclient.cnf
@@ -1,4 +1,6 @@
 [client]
 user=db
 password=db
+
+[mysql]
 database=db


### PR DESCRIPTION
## The Problem:

mysqldump and drush sql-dump complain about syntax of --databases, see OP #43

The fix is easy as shown in the OP.


## The Fix:

## The Test:

`ddev ssh` into this container and do a mysqldump. Or `docker run -it`

You can test this with the pushed container `dbimage: drud/mariadb-local:20180302_fix_my_cnf`  - use it with ddev in a config.yaml and `ddev ssh -s db`.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

