### PR TITLE
Remove utf8mb4 config for databases that can't handle it, DO NOT PULL, For drud/ddev#654

### DIFF
--- a/files/etc/my.cnf
+++ b/files/etc/my.cnf
@@ -28,9 +28,6 @@ skip-log-bin
 datadir=/var/lib/mysql
 secure-file-priv=/var/lib/mysql-files
 
-character-set-server = utf8mb4
-collation-server = utf8mb4_bin
-
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0
 
@@ -67,8 +64,6 @@ innodb-log-file-size           = 64M
 innodb-flush-log-at-trx-commit = 2
 innodb-file-per-table          = 1
 innodb-buffer-pool-size        = 1024M
-innodb_large_prefix=true
-innodb_file_format=barracuda
 innodb_file_per_table=true
 
 # LOGGING #


### PR DESCRIPTION
## The Problem:

This PR is just to document temporary removal of utf8mb4 for a temporary image (pushed as image `drud/mariadb-local:v0.7.1-no_utf8mb4`

OP: drud/ddev#654

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

