### PR TITLE
Tail mariadb.log for ddev and docker logs, fixes #47 #TRIVIALREVIEW

### DIFF
--- a/files/docker-entrypoint.sh
+++ b/files/docker-entrypoint.sh
@@ -37,4 +37,5 @@ chgrp mysql /var/tmp
 chmod ug+w /var/tmp
 
 echo "Starting mysqld."
+tail -f /var/log/mysqld.log &
 exec mysqld --max-allowed-packet=${MYSQL_MAX_ALLOWED_PACKET:-16m}


### PR DESCRIPTION
## The Problem:

OP #47: We have been unable to see serious mariadb errors because only the output of the daemon has been shown, but the real action is in /var/log/mysqld.log. 

## The Fix:

Begin tailing the log as well.

## The Test:

Build the container (or use `dbimage: drud/mariadb-local:20180307_tail_maria_log` in .ddev/config.yaml).
ddev logs -s db -f
To make something happen, `ddev ssh -s db` in another window and `killall -1 mysqld`. You should see action in the tailed logs.

## Automation Overview:


## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

