### PR TITLE
[do not merge] Add innodb_force_recovery = 1, fixes drud/ddev#748

### DIFF
--- a/files/etc/my.cnf
+++ b/files/etc/my.cnf
@@ -6,6 +6,7 @@ socket                         = /var/tmp/mysql.sock
 
 [mysqld]
 
+
 #
 # Remove leading # and set to the amount of RAM for the most important data
 # cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
@@ -70,6 +71,10 @@ innodb-buffer-pool-size        = 1024M
 innodb_large_prefix=true
 innodb_file_format=barracuda
 innodb_file_per_table=true
+
+# Docker daemon stop or host restart seems to give no notice to the
+# container to shut down properly. Try a gentle
+innodb_force_recovery = 1
 
 # LOGGING #
 log-error                      = /var/log/mysqld.log


### PR DESCRIPTION
## The Problem:

OP drud/ddev#748: Docker does not seem to properly notify container for clean shutdown, so we need to do a gentle force_recovery.

To test, work with a ddev project with `dbimage: drud/mariadb-local:20180321_force_recovery` in config.yaml

* configure, start, and Import a nontrivial database in a ddev project
* Exit the docker daemon (exit docker on macOS)
* Start docker back up
* `ddev start` (it's stopped after docker goes down and comes back up)
* Database should come up ok.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

